### PR TITLE
Command Line to manually set the Echo IP adresse

### DIFF
--- a/ServiceDll/ServiceDll.vcxproj
+++ b/ServiceDll/ServiceDll.vcxproj
@@ -154,6 +154,8 @@
   <ItemGroup>
     <ClInclude Include="src\Network.h" />
     <ClInclude Include="src\NetworkException.h" />
+    <ClInclude Include="src\Server.h" />
+    <ClInclude Include="src\ServerOptions.h" />
     <ClInclude Include="src\UDPSender.h" />
     <ClInclude Include="src\UDPReceiver.h" />
     <ClInclude Include="src\Util.h" />
@@ -162,6 +164,7 @@
     <ClCompile Include="src\Network.cpp" />
     <ClCompile Include="src\NetworkException.cpp" />
     <ClCompile Include="src\Server.cpp" />
+    <ClCompile Include="src\ServerOptions.cpp" />
     <ClCompile Include="src\UDPSender.cpp" />
     <ClCompile Include="src\UDPReceiver.cpp" />
     <ClCompile Include="src\Util.cpp" />

--- a/ServiceDll/ServiceDll.vcxproj.filters
+++ b/ServiceDll/ServiceDll.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClInclude Include="src\Util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\Server.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\ServerOptions.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\NetworkException.cpp">
@@ -48,6 +54,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\Util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\ServerOptions.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/ServiceDll/src/Network.cpp
+++ b/ServiceDll/src/Network.cpp
@@ -1,6 +1,11 @@
-#include "Network.h"
 #pragma comment(lib, "Ws2_32.lib")
+#define _WINSOCK_DEPRECATED_NO_WARNINGS
+
+#include "Network.h"
+
 #include <iostream>
+#include <WinSock2.h>
+#include <WS2tcpip.h>
 #include <Windows.h>
 
 bool GetMyIP(struct IPv4& myIP)

--- a/ServiceDll/src/Network.cpp
+++ b/ServiceDll/src/Network.cpp
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <Windows.h>
 
-
-
 bool GetMyIP(struct IPv4& myIP)
 {
     char szBuffer[1024];

--- a/ServiceDll/src/Network.h
+++ b/ServiceDll/src/Network.h
@@ -1,9 +1,4 @@
 #pragma once
-#define _WINSOCK_DEPRECATED_NO_WARNINGS
-#include <WinSock2.h>
-#include <WS2tcpip.h>
-
-
 
 struct IPv4
 {

--- a/ServiceDll/src/NetworkException.cpp
+++ b/ServiceDll/src/NetworkException.cpp
@@ -1,4 +1,3 @@
-
 #include "NetworkException.h"
 
 NetworkException::NetworkException(std::string message, std::string file, int line)

--- a/ServiceDll/src/NetworkException.h
+++ b/ServiceDll/src/NetworkException.h
@@ -1,8 +1,5 @@
 #pragma once
 #include <string>
-#include <exception>
-
-
 
 #ifndef NDEBUG
 #include <iostream>
@@ -10,7 +7,6 @@
 #else
 #define LOG_ERR
 #endif
-
 
 class NetworkException:public std::exception
 {

--- a/ServiceDll/src/NetworkException.h
+++ b/ServiceDll/src/NetworkException.h
@@ -6,7 +6,7 @@
 
 #ifndef NDEBUG
 #include <iostream>
-#define LOG_ERR std::cerr << "Error At : " << __FILE__ << " : " << __LINE__ << std::endl
+#define LOG_ERR std::cerr << "Error At : " << __FILE__ << " : " << __LINE__ << ", Code : " << WSAGetLastError() << std::endl
 #else
 #define LOG_ERR
 #endif

--- a/ServiceDll/src/Server.cpp
+++ b/ServiceDll/src/Server.cpp
@@ -5,6 +5,13 @@
 #include "Server.h"
 #include "ServerOptions.h"
 
+#include <iostream>
+#include <thread>
+#include <cmath>
+#include <Windows.h>
+#include <WinUser.h>
+#include <unordered_map>
+
 void ServerThread() {
 	UDPReceiver server(SERVER_PORT);
 

--- a/ServiceDll/src/Server.h
+++ b/ServiceDll/src/Server.h
@@ -1,9 +1,5 @@
 #pragma once
-#include <iostream>
-#include <thread>
-#include <cmath>
-#include <Windows.h>
-#include <WinUser.h>
+#include "Network.h"
 
 constexpr unsigned short int ECHO_PORT = 5560;
 constexpr unsigned short int SERVER_PORT = 5559;

--- a/ServiceDll/src/Server.h
+++ b/ServiceDll/src/Server.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <iostream>
+#include <thread>
+#include <cmath>
+#include <Windows.h>
+#include <WinUser.h>
+
+constexpr unsigned short int ECHO_PORT = 5560;
+constexpr unsigned short int SERVER_PORT = 5559;
+
+void EchoThread();
+void EchoThreadA(IPv4 ip);
+void ServerThread();

--- a/ServiceDll/src/ServerOptions.cpp
+++ b/ServiceDll/src/ServerOptions.cpp
@@ -1,6 +1,8 @@
 // https://stackoverflow.com/a/868894
 #include "ServerOptions.h"
 
+#include <iostream>
+
 char* GetCmdOption(char** begin, char** end, const std::string& option)
 {
     char** itr = std::find(begin, end, option);

--- a/ServiceDll/src/ServerOptions.cpp
+++ b/ServiceDll/src/ServerOptions.cpp
@@ -1,0 +1,17 @@
+// https://stackoverflow.com/a/868894
+#include "ServerOptions.h"
+
+char* GetCmdOption(char** begin, char** end, const std::string& option)
+{
+    char** itr = std::find(begin, end, option);
+    if (itr != end && ++itr != end)
+    {
+        return *itr;
+    }
+    return 0;
+}
+
+bool CmdOptionExists(char** begin, char** end, const std::string& option)
+{
+    return std::find(begin, end, option) != end;
+}

--- a/ServiceDll/src/ServerOptions.h
+++ b/ServiceDll/src/ServerOptions.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <iostream>
+#include <string>
 
 char* GetCmdOption(char** begin, char** end, const std::string& option);
 bool CmdOptionExists(char** begin, char** end, const std::string& option);

--- a/ServiceDll/src/ServerOptions.h
+++ b/ServiceDll/src/ServerOptions.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <iostream>
+
+char* GetCmdOption(char** begin, char** end, const std::string& option);
+bool CmdOptionExists(char** begin, char** end, const std::string& option);

--- a/ServiceDll/src/UDPReceiver.cpp
+++ b/ServiceDll/src/UDPReceiver.cpp
@@ -1,6 +1,7 @@
-#include "NetworkException.h"
 #pragma comment (lib,"ws2_32.lib")
+
 #include "UDPReceiver.h"
+#include "NetworkException.h"
 
 UDPReceiver::UDPReceiver(unsigned short int port) {
 	this->port = port;

--- a/ServiceDll/src/UDPReceiver.cpp
+++ b/ServiceDll/src/UDPReceiver.cpp
@@ -1,33 +1,6 @@
-
 #include "NetworkException.h"
 #pragma comment (lib,"ws2_32.lib")
 #include "UDPReceiver.h"
-
-
-
-#define DEFAULT_PORT 10117
-
-UDPReceiver::UDPReceiver(){
-	this->port = DEFAULT_PORT;
-	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-		LOG_ERR;
-		throw NetworkException("WSA Startup failed", __FILE__, __LINE__);
-	}
-	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if (sock == INVALID_SOCKET) {
-		LOG_ERR;
-		throw NetworkException("Socket Open Failed", __FILE__, __LINE__);
-	}
-	toRecv.sin_port = htons(this->port);
-	toRecv.sin_family = AF_INET;
-	toRecv.sin_addr.s_addr = ADDR_ANY;
-	int ret = bind(sock, reinterpret_cast<SOCKADDR*>(&toRecv), sizeof(toRecv));
-	if (ret < 0) {
-		LOG_ERR;
-		throw NetworkException("Socket Bind Failed", __FILE__, __LINE__);
-	}
-	this->addrSize = sizeof(toRecv);
-}
 
 UDPReceiver::UDPReceiver(unsigned short int port) {
 	this->port = port;
@@ -53,29 +26,6 @@ UDPReceiver::UDPReceiver(unsigned short int port) {
 	this->addrSize = sizeof(toRecv);
 }
 
-UDPReceiver::UDPReceiver(IPv4 ip) {
-	this->port = DEFAULT_PORT;
-	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-		LOG_ERR;
-		throw NetworkException("WSA Startup failed", __FILE__, __LINE__);
-	}
-	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if (sock == INVALID_SOCKET) {
-		LOG_ERR;
-		throw NetworkException("Socket Open Failed", __FILE__, __LINE__);
-	}
-
-	toRecv.sin_port = htons(this->port);
-	toRecv.sin_family = AF_INET;
-	toRecv.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
-
-	int ret = bind(sock, reinterpret_cast<SOCKADDR*>(&toRecv), sizeof(toRecv));
-	if (ret < 0) {
-		LOG_ERR;
-		throw NetworkException("Socket Bind Failed", __FILE__, __LINE__);
-	}
-	this->addrSize = sizeof(toRecv);
-}
 UDPReceiver::UDPReceiver(IPv4 ip, unsigned short int port) {
 	this->port = port;
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {

--- a/ServiceDll/src/UDPReceiver.h
+++ b/ServiceDll/src/UDPReceiver.h
@@ -1,7 +1,9 @@
 #pragma once
 #include "Network.h"
 
-constexpr unsigned short int DEFAULT_PORT = 10117;
+#include <WinSock2.h>
+
+#define DEFAULT_PORT 10117
 
 class UDPReceiver
 {

--- a/ServiceDll/src/UDPReceiver.h
+++ b/ServiceDll/src/UDPReceiver.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "Network.h"
 
+constexpr unsigned short int DEFAULT_PORT = 10117;
+
 class UDPReceiver
 {
 private:
@@ -11,10 +13,8 @@ private:
     int addrSize;
 
 public:
-    UDPReceiver();
-    UDPReceiver(unsigned short int port);
-    UDPReceiver(IPv4 ip);
-    UDPReceiver(IPv4 ip, unsigned short int port);
+    UDPReceiver(unsigned short int port = DEFAULT_PORT);
+    UDPReceiver(IPv4 ip, unsigned short int port = DEFAULT_PORT);
     ~UDPReceiver();
 
 public:

--- a/ServiceDll/src/UDPSender.cpp
+++ b/ServiceDll/src/UDPSender.cpp
@@ -2,9 +2,6 @@
 #include "NetworkException.h"
 #pragma comment (lib,"ws2_32.lib")
 
-
-#define DEFAULT_PORT 10117
-
 UDPSender::UDPSender(unsigned short int port) {
 	this->port = port;
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
@@ -17,10 +14,10 @@ UDPSender::UDPSender(unsigned short int port) {
 		throw NetworkException("Socket Open Failed", __FILE__, __LINE__);
 	}
 
+	// TODO: Check if `toSend` should be initialized here? (C++ C26495 throw by Visual Studio)
 }
 
-
-UDPSender::UDPSender(IPv4 ip,unsigned short int port) {
+UDPSender::UDPSender(IPv4 ip, unsigned short int port) {
 	this->port = port;
 	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
 		LOG_ERR;
@@ -35,36 +32,6 @@ UDPSender::UDPSender(IPv4 ip,unsigned short int port) {
 	toSend.sin_family = AF_INET;
 	toSend.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
 	toSend.sin_port = htons(port);
-}
-
-UDPSender::UDPSender(IPv4 ip) {
-	this->port = DEFAULT_PORT;
-	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-		LOG_ERR;
-		throw NetworkException("WSA Startup failed", __FILE__, __LINE__);
-	}
-	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if (sock == INVALID_SOCKET) {
-		LOG_ERR;
-		throw NetworkException("Socket Open Failed", __FILE__, __LINE__);
-	}
-	toSend.sin_family = AF_INET;
-	toSend.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
-	toSend.sin_port = this->port;
-}
-
-UDPSender::UDPSender() {
-	this->port = DEFAULT_PORT;
-	if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
-		LOG_ERR;
-		throw NetworkException("WSA Startup failed", __FILE__, __LINE__);
-	}
-	sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-	if (sock == INVALID_SOCKET) {
-		LOG_ERR;
-		throw NetworkException("Socket Open Failed", __FILE__, __LINE__);
-	}
-	
 }
 
 UDPSender::~UDPSender() {
@@ -74,15 +41,12 @@ UDPSender::~UDPSender() {
 	WSACleanup();
 }
 
-int UDPSender::Bind(IPv4 ip, unsigned short int port) {
-	this->port = port;
-	toSend.sin_family = AF_INET;
-	toSend.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
-	toSend.sin_port = htons(port);
-	return 0;
+int UDPSender::Bind(IPv4 ip) {
+	return Bind(ip, port);
 }
 
-int UDPSender::Bind(IPv4 ip) {
+int UDPSender::Bind(IPv4 ip, unsigned short int port) {
+	this->port = port;
 	toSend.sin_family = AF_INET;
 	toSend.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
 	toSend.sin_port = htons(port);
@@ -97,32 +61,15 @@ int UDPSender::Bind(unsigned short int port) {
 
 
 int UDPSender::Send(const char* data,int size,int flags) {
-	int ret = sendto(sock, data, size, flags, reinterpret_cast<SOCKADDR*>(&toSend), sizeof(toSend));
-	if (ret < 0) {
-		LOG_ERR;
-		//throw std::system_error(WSAGetLastError(), std::system_category(), "sendto failed");
-		throw NetworkException("Data Send Failed", __FILE__, __LINE__);
-	}
-	return ret;
+	return Send(data, size, toSend, flags);
 }
 
-
 int UDPSender::Send(const char* data, int size, IPv4 ip, int flags) {
-	sockaddr_in add;
-	add.sin_family = AF_INET;
-	add.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
-	add.sin_port = htons(port);
-	int ret = sendto(sock, data, size, flags, reinterpret_cast<SOCKADDR*>(&add), sizeof(add));
-	if (ret < 0) {
-		LOG_ERR;
-		//throw std::system_error(WSAGetLastError(), std::system_category(), "sendto failed");
-		throw NetworkException("Data Send Failed", __FILE__, __LINE__);
-	}
-	return ret;
+	return Send(data, size, ip, port, flags);
 }
 
 int UDPSender::Send(const char* data, int size, IPv4 ip, unsigned short int port, int flags) {
-	sockaddr_in add;
+	sockaddr_in add{};
 	add.sin_family = AF_INET;
 	add.sin_addr.S_un.S_un_b = { ip.s_b1,ip.s_b2,ip.s_b3,ip.s_b4 };
 	add.sin_port = htons(port);

--- a/ServiceDll/src/UDPSender.cpp
+++ b/ServiceDll/src/UDPSender.cpp
@@ -1,6 +1,7 @@
+#pragma comment (lib,"ws2_32.lib")
+
 #include "UDPSender.h"
 #include "NetworkException.h"
-#pragma comment (lib,"ws2_32.lib")
 
 UDPSender::UDPSender(unsigned short int port) {
 	this->port = port;

--- a/ServiceDll/src/UDPSender.h
+++ b/ServiceDll/src/UDPSender.h
@@ -1,7 +1,9 @@
 #pragma once
 #include "Network.h"
 
-constexpr auto DEFAULT_PORT = 10117;
+#include <WinSock2.h>
+
+#define DEFAULT_PORT 10117
 
 class UDPSender
 {
@@ -13,7 +15,6 @@ private:
 
 public:
     UDPSender(unsigned short int port = DEFAULT_PORT);
-    UDPSender(IPv4 ip);
     UDPSender(IPv4 ip, unsigned short int port = DEFAULT_PORT);
     ~UDPSender();
 

--- a/ServiceDll/src/UDPSender.h
+++ b/ServiceDll/src/UDPSender.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "Network.h"
 
+constexpr auto DEFAULT_PORT = 10117;
+
 class UDPSender
 {
 private:
@@ -10,10 +12,9 @@ private:
     unsigned short port;
 
 public:
-    UDPSender();
-    UDPSender(unsigned short int port);
+    UDPSender(unsigned short int port = DEFAULT_PORT);
     UDPSender(IPv4 ip);
-    UDPSender(IPv4 ip, unsigned short int port);
+    UDPSender(IPv4 ip, unsigned short int port = DEFAULT_PORT);
     ~UDPSender();
 
 public:

--- a/ServiceDll/src/Util.cpp
+++ b/ServiceDll/src/Util.cpp
@@ -1,4 +1,7 @@
 #include "Util.h"
+
+#include <Windows.h>
+
 int ReadJSON(const std::string& buff, std::unordered_map<std::string, std::string>& input) {
 	int i = 0;
 	char ch = buff[i];

--- a/ServiceDll/src/Util.h
+++ b/ServiceDll/src/Util.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <Windows.h>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
Hello,

I wanted to try out your app; however, I encountered the same issue as reported in #1. The server automatically selects the wrong network card, especially when multiple virtual ones are present on my machine due to VPN and VM configurations.

To address this, I've implemented a solution allowing users to manually set the Echo IP address. I achieved this by creating a command-line parser with the `-a` option to specify the desired IP address.

Simultaneously, I noticed the presence of duplicate methods, which is considered bad practice. In this pull request, I have addressed this issue by cleaning up the code and using default parameters.

I apologize for not creating a separate pull request for the cleanup; I hope this combined approach is acceptable.